### PR TITLE
Enable email to be sent to newly added participants

### DIFF
--- a/graphqlSchema/schema.js
+++ b/graphqlSchema/schema.js
@@ -106,7 +106,7 @@ const getParticipantsByEventId = (eventId) => {
 	});
 };
 
-const createParticipantObject = (input) => {
+const createParticipantObject = async (input) => {
 	db.Participant.create({
 		first_name: input.first_name,
 		last_name: input.last_name,
@@ -115,17 +115,18 @@ const createParticipantObject = (input) => {
 		date_sent: new Date(),
 		EventId: input.EventId,
 	});
-	var eventData = root.getEvent(input.EventId);
+	var eventData = await db.Event.findOne({ where: { id: input.EventId } });
+	console.log("EVENT DATA: " + JSON.stringify(eventData));
 
 	// calling invitationEmail function when participant is created
 	// so participant can get email once added to event
 	invitationEmail(
-		"krystal.e.garcia@gmail.com",
-		"Krystal Duran",
-		"Test Description",
-		"12/12/2020",
-		"7pm",
-		"remote link",
+		input.email,
+		eventData.planner_email,
+		eventData.description,
+		eventData.date,
+		eventData.start_time,
+		eventData.location
 	);
 };
 

--- a/graphqlSchema/schema.js
+++ b/graphqlSchema/schema.js
@@ -115,6 +115,8 @@ const createParticipantObject = (input) => {
 		date_sent: new Date(),
 		EventId: input.EventId,
 	});
+	var eventData = root.getEvent(input.EventId);
+
 	// calling invitationEmail function when participant is created
 	// so participant can get email once added to event
 	invitationEmail(
@@ -123,7 +125,7 @@ const createParticipantObject = (input) => {
 		"Test Description",
 		"12/12/2020",
 		"7pm",
-		"remote link"
+		"remote link",
 	);
 };
 

--- a/graphqlSchema/schema.js
+++ b/graphqlSchema/schema.js
@@ -1,6 +1,7 @@
 const { buildSchema } = require("graphql");
 const { random } = require("lodash");
 const _ = require("lodash");
+const invitationEmail = require("../utils/inviteEmail");
 const db = require("./../models");
 var schema = buildSchema(`
 	input InputEvent {
@@ -114,6 +115,9 @@ const createParticipantObject = (input) => {
 		date_sent: new Date(),
 		EventId: input.EventId,
 	});
+	// calling invitationEmail function when participant is created
+	// so participant can get email once added to event
+	invitationEmail(email, planner, description, date, start_time, location);
 };
 
 const assignSecretSanta = (participant_id, secret_santa_id) => {

--- a/graphqlSchema/schema.js
+++ b/graphqlSchema/schema.js
@@ -117,7 +117,14 @@ const createParticipantObject = (input) => {
 	});
 	// calling invitationEmail function when participant is created
 	// so participant can get email once added to event
-	invitationEmail(email, planner, description, date, start_time, location);
+	invitationEmail(
+		"krystal.e.garcia@gmail.com",
+		"Krystal Duran",
+		"Test Description",
+		"12/12/2020",
+		"7pm",
+		"remote link"
+	);
 };
 
 const assignSecretSanta = (participant_id, secret_santa_id) => {

--- a/utils/inviteEmail.js
+++ b/utils/inviteEmail.js
@@ -21,9 +21,9 @@ async function invitationEmail(
 			pass: process.env.GMAIL_PASSWORD,
 		},
 		tls: {
-			rejectUnauthorized: false
+			rejectUnauthorized: false,
 		},
-		secure: false, 
+		secure: false,
 	});
 
 	// send mail with defined transport object
@@ -31,18 +31,18 @@ async function invitationEmail(
 		{
 			from: '"Secret Santa App" <secretsanta.partyapp@gmail.com>', // sender address
 			to: `${email}`, // list of receivers
-			subject: `${planner} sent you a Secret Santa invitation!`, // Subject line
+			subject: `Someone sent you a Secret Santa invitation!`, // Subject line
 			text: " ", // plain text body - nothing included here at this time
 			html: `<b>
 		<h1>You are invited the ${description} Secret Santa Party!</h>
-		<p>Here Secret Santa Party information.</p>
+		<p>${planner} sent you a Secret Santa invitation. Here Secret Santa Party information.</p>
 		<li>
 			<ul>Date: ${date}</ul>
 			<ul>Time: ${start_time}</ul>
 			<ul>Location: ${location}</ul>
 		</li>
 
-		<p>Please let ${planner} know if you plan on attending this Secret Santa event by 
+		<p>Please let your host know if you plan on attending this Secret Santa event by 
 		clicking on the link provided below to RSVP for the event. The link provided below will
 		redirect you to the Secret Santa App platform.</p>
 

--- a/utils/inviteEmail.js
+++ b/utils/inviteEmail.js
@@ -3,7 +3,14 @@ require("dotenv").config();
 const nodemailer = require("nodemailer");
 
 // async..await is not allowed in global scope, must use a wrapper
-async function invitationEmail() {
+async function invitationEmail(
+	email,
+	planner,
+	description,
+	date,
+	start_time,
+	location
+) {
 	console.log("Testing: this is the email " + email);
 	// create reusable transporter object using the default SMTP transport
 	let transporter = nodemailer.createTransport({
@@ -19,7 +26,7 @@ async function invitationEmail() {
 	let info = await transporter.sendMail({
 		from: '"Secret Santa App" <secretsanta.partyapp@gmail.com>', // sender address
 		to: `${email}`, // list of receivers
-		subject: `${organizer} sent you a Secret Santa invitation!`, // Subject line
+		subject: `${planner} sent you a Secret Santa invitation!`, // Subject line
 		text: " ", // plain text body - nothing included here at this time
 		html: `<b>
 		<h1>You are invited the ${description} Secret Santa Party!</h>
@@ -30,7 +37,7 @@ async function invitationEmail() {
 			<ul>Location: ${location}</ul>
 		</li>
 
-		<p>Please let ${organizer} know if you plan on attending this Secret Santa event by 
+		<p>Please let ${planner} know if you plan on attending this Secret Santa event by 
 		clicking on the link provided below to RSVP for the event. The link provided below will
 		redirect you to the Secret Santa App platform.</p>
 

--- a/utils/inviteEmail.js
+++ b/utils/inviteEmail.js
@@ -20,15 +20,20 @@ async function invitationEmail(
 			user: process.env.GMAIL_USER,
 			pass: process.env.GMAIL_PASSWORD,
 		},
+		tls: {
+			rejectUnauthorized: false
+		},
+		secure: false, 
 	});
 
 	// send mail with defined transport object
-	let info = await transporter.sendMail({
-		from: '"Secret Santa App" <secretsanta.partyapp@gmail.com>', // sender address
-		to: `${email}`, // list of receivers
-		subject: `${planner} sent you a Secret Santa invitation!`, // Subject line
-		text: " ", // plain text body - nothing included here at this time
-		html: `<b>
+	let info = await transporter.sendMail(
+		{
+			from: '"Secret Santa App" <secretsanta.partyapp@gmail.com>', // sender address
+			to: `${email}`, // list of receivers
+			subject: `${planner} sent you a Secret Santa invitation!`, // Subject line
+			text: " ", // plain text body - nothing included here at this time
+			html: `<b>
 		<h1>You are invited the ${description} Secret Santa Party!</h>
 		<p>Here Secret Santa Party information.</p>
 		<li>
@@ -46,10 +51,18 @@ async function invitationEmail(
 			https://secret-santa-platform.herokuapp.com/</a></ul>
 		</li>
         </b>`, // html body
-	});
+		},
+		(err, success) => {
+			if (err) {
+				console.log(err);
+			} else {
+				console.log(success);
+			}
+		}
+	);
 
-	console.log("Message sent: %s", info.messageId);
-	// Message sent: <b658f8ca-6296-ccf4-8306-87d57a0b4321@example.com>
+	// console.log("Message sent: %s", info.messageId);
+	// // Message sent: <b658f8ca-6296-ccf4-8306-87d57a0b4321@example.com>
 }
 
 module.exports = invitationEmail;


### PR DESCRIPTION
In this branch, I added the following:

- [x] make sure email sends
- [x] new participants get email when added
- [x] email directs recipient to homepage for login
- [x] test on Heroku

Please note that a sample test was conducted with Yadira and Joshua to confirm the email content does sent when a participant is added. 

Here is a list of additional items that will follow in the next issue:

- Direct invited participant to RSVP page
- Log RSVP status
- Confirm with the team on whether we will delete the participants or just filter out guests who decide not to attend

closes #115 

### Test Case Event in Heroku
![image](https://user-images.githubusercontent.com/58799056/94620483-57f3f600-0274-11eb-8bb8-58507f4c7a7a.png)

### Image of Email sent to Participant (i.e. me for this demo)
![image](https://user-images.githubusercontent.com/58799056/94620452-47dc1680-0274-11eb-9eb1-d288fabecbed.png)
