### PR TITLE
Completed functionality for RSVP Page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -44,7 +44,7 @@ const AppContent = ({ isAuthenticated }) => {
 					path="/events/:id/participant/:participantid/addgift"
 					component={AddGift}
 				/>
-				<Route
+				<PrivateRoute
 					exact
 					path="/events/:id/rsvp/:participantid"
 					component={RsvpEvent}

--- a/client/src/actions/graphql.api.js
+++ b/client/src/actions/graphql.api.js
@@ -11,6 +11,8 @@ import {
 	getParticipantByEventIdAndEmailQuery,
 	getGiftByParticipantIdQuery,
 	autoAssignSecretSantaMutation,
+	participantAcceptedInviteMutation,
+	participantRejectedInviteMutation,
 } from "./graphql.queries";
 
 const endpoint = "/graphql";
@@ -220,6 +222,34 @@ const autoAssignSecretSanta = (eventId, token, onSuccess, onError) => {
 	);
 };
 
+const participantAcceptedInvite = (id, token, onSuccess, onError) => {
+	const variables = {
+		id: id,
+	};
+
+	return processWithClient(
+		token,
+		participantAcceptedInviteMutation,
+		variables,
+		onSuccess,
+		onError
+	);
+};
+
+const participantRejectedInvite = (id, token, onSuccess, onError) => {
+	const variables = {
+		id: id,
+	};
+
+	return processWithClient(
+		token,
+		participantRejectedInviteMutation,
+		variables,
+		onSuccess,
+		onError
+	);
+};
+
 export {
 	graphQLClient,
 	processWithClient,
@@ -233,4 +263,6 @@ export {
 	getParticipantByEventIdAndEmail,
 	autoAssignSecretSanta,
 	getGiftByParticipantId,
+	participantAcceptedInvite,
+	participantRejectedInvite,
 };

--- a/client/src/actions/graphql.api.test.js
+++ b/client/src/actions/graphql.api.test.js
@@ -12,6 +12,8 @@ import {
 	getParticipantByEventIdAndEmail,
 	createGift,
 	autoAssignSecretSanta,
+	participantAcceptedInvite,
+	participantRejectedInvite,
 } from "./graphql.api";
 import { GraphQLClient } from "graphql-request";
 
@@ -153,6 +155,26 @@ describe("graph apis", () => {
 	test("process autoAssignSecretSanta success", () => {
 		mockGrapgqlClientSuccess({});
 		autoAssignSecretSanta(
+			1,
+			"token",
+			() => {},
+			() => {}
+		);
+	});
+
+	test("process participantAcceptedInvite success", () => {
+		mockGrapgqlClientSuccess(1);
+		participantAcceptedInvite(
+			1,
+			"token",
+			() => {},
+			() => {}
+		);
+	});
+
+	test("process participantRejectedInvite success", () => {
+		mockGrapgqlClientSuccess(1);
+		participantRejectedInvite(
 			1,
 			"token",
 			() => {},

--- a/client/src/actions/graphql.queries.js
+++ b/client/src/actions/graphql.queries.js
@@ -57,6 +57,7 @@ const getParticipantsbyEventIdQuery = gql`
 			id
 			first_name
 			last_name
+			invite_status
 			email
 			SecretSanta {
 				id

--- a/client/src/actions/graphql.queries.js
+++ b/client/src/actions/graphql.queries.js
@@ -108,6 +108,22 @@ const autoAssignSecretSantaMutation = gql`
 	}
 `;
 
+const participantAcceptedInviteMutation = gql`
+	mutation updateParticipantAccepted($id: Int!) {
+		updateParticipantAccepted(id: $id) {
+			id
+		}
+	}
+`;
+
+const participantRejectedInviteMutation = gql`
+	mutation updateParticipantRejected($id: Int!) {
+		updateParticipantRejected(id: $id) {
+			id
+		}
+	}
+`;
+
 export {
 	createEventMutation,
 	createParticipantMutation,
@@ -119,4 +135,6 @@ export {
 	getParticipantByEventIdAndEmailQuery,
 	getGiftByParticipantIdQuery,
 	autoAssignSecretSantaMutation,
+	participantAcceptedInviteMutation,
+	participantRejectedInviteMutation,
 };

--- a/client/src/actions/graphql.queries.test.js
+++ b/client/src/actions/graphql.queries.test.js
@@ -11,6 +11,8 @@ import {
 	getParticipantByEventIdAndEmailQuery,
 	createGiftMutation,
 	autoAssignSecretSantaMutation,
+	participantRejectedInviteMutation,
+	participantAcceptedInviteMutation,
 } from "./graphql.queries";
 
 describe("gql statements", () => {
@@ -53,6 +55,16 @@ describe("gql statements", () => {
 	test("validate autoAssignSecretSantaMutation mutation", () => {
 		expect(autoAssignSecretSantaMutation).toMatch(
 			/mutation autoAssignSecretSanta/
+		);
+	});
+	test("validate updated invite status change to accepted", () => {
+		expect(participantAcceptedInviteMutation).toMatch(
+			/mutation updateParticipantAccepted/
+		);
+	});
+	test("validate updated invite status change to rejected", () => {
+		expect(participantRejectedInviteMutation).toMatch(
+			/mutation updateParticipantRejected/
 		);
 	});
 });

--- a/client/src/pages/OrganizerEvent/OrganizerEvent.js
+++ b/client/src/pages/OrganizerEvent/OrganizerEvent.js
@@ -144,7 +144,11 @@ const setParticipantData = (d, setData, setRsvpCounts) => {
 				: "",
 			secretEmail: participant.SecretSanta ? participant.SecretSanta.email : "",
 		};
-		formattedData.push(participantEntry);
+
+		if (participant.invite_status !== "Rejected") {
+			formattedData.push(participantEntry);
+		}
+
 		switch (participant.invite_status) {
 			case "Accepted":
 				rsvpCounts.accepted += 1;

--- a/client/src/pages/RsvpEvent/RsvpEvent.js
+++ b/client/src/pages/RsvpEvent/RsvpEvent.js
@@ -1,23 +1,54 @@
 import React, { useState, useEffect } from "react";
 import { Row, notification } from "antd";
+import { Redirect } from "react-router";
 import ResponsiveColumn from "../../components/ResponsiveColumn";
 import DetailCard from "../../components/DetailCard/DetailCard";
 import Button from "../../components/Button";
 import "./style.css";
-import { getEventByEventId } from "../../actions/graphql.api";
+import {
+	getEventByEventId,
+	participantAcceptedInvite,
+	participantRejectedInvite,
+} from "../../actions/graphql.api";
 import { useAuth0 } from "@auth0/auth0-react";
 
-const processStatusAction = (status, setStatusCallBack) => {
+const processStatusAction = (
+	status,
+	setStatusCallBack,
+	eventId,
+	participantId,
+	token,
+	setNextUrl,
+	setParticipantMadeChoice
+) => {
 	if (status === "Accepted") {
-		notification.success({
-			message: "Going",
-			description: "You Have been added to the event list",
-		});
+		participantAcceptedInvite(
+			participantId,
+			token,
+			() => {
+				notification.success({
+					message: "Going",
+					description: "You have been added to the event list",
+				});
+				setNextUrl(`/events/${eventId}/participant`);
+				setParticipantMadeChoice(true);
+			},
+			(e) => showError(e)
+		);
 	} else if (status === "Rejected") {
-		notification.warn({
-			message: "Not Going",
-			description: "No worries, we will notify the event host",
-		});
+		participantRejectedInvite(
+			participantId,
+			token,
+			() => {
+				notification.warn({
+					message: "Not Going",
+					description: "No worries, we will notify the event host",
+				});
+				setNextUrl(`/`);
+				setParticipantMadeChoice(true);
+			},
+			(e) => showError(e)
+		);
 	}
 	setStatusCallBack(status);
 };
@@ -30,10 +61,13 @@ const showError = (error) => {
 };
 
 const RsvpEvent = (props) => {
+	const [participantMadeChoice, setParticipantMadeChoice] = useState(false);
+	const [nextUrl, setNextUrl] = useState("");
 	const [eventData, setEventData] = useState({});
 	const [status, setStatus] = useState(null);
 	const { getAccessTokenSilently } = useAuth0();
 	const eventId = parseInt(props.match.params.id);
+	const participantId = parseInt(props.match.params.participantid);
 
 	// Rendering event info
 	useEffect(() => {
@@ -47,6 +81,7 @@ const RsvpEvent = (props) => {
 
 	return (
 		<>
+			{participantMadeChoice && <Redirect to={nextUrl} />}
 			<Row gutter={[30, 30]} justify="center">
 				<ResponsiveColumn style={{ padding: 40 }} lg={9} md={9}>
 					<DetailCard
@@ -59,14 +94,34 @@ const RsvpEvent = (props) => {
 								testid="going-btn"
 								text="Going"
 								disabled={status === "Accepted"}
-								action={() => processStatusAction("Accepted", setStatus)}
+								action={() =>
+									processStatusAction(
+										"Accepted",
+										setStatus,
+										eventId,
+										participantId,
+										getAccessTokenSilently(),
+										setNextUrl,
+										setParticipantMadeChoice
+									)
+								}
 							/>,
 							<Button
 								testid="not-going-btn"
 								text="Not Going"
 								disabled={status === "Rejected"}
 								bgColor="#D62828"
-								action={() => processStatusAction("Rejected", setStatus)}
+								action={() =>
+									processStatusAction(
+										"Rejected",
+										setStatus,
+										eventId,
+										participantId,
+										getAccessTokenSilently(),
+										setNextUrl,
+										setParticipantMadeChoice
+									)
+								}
 							/>,
 						]}
 					/>

--- a/client/src/pages/RsvpEvent/RsvpEvent.js
+++ b/client/src/pages/RsvpEvent/RsvpEvent.js
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Row, notification } from "antd";
 import ResponsiveColumn from "../../components/ResponsiveColumn";
 import DetailCard from "../../components/DetailCard/DetailCard";
 import Button from "../../components/Button";
 import "./style.css";
+import { getEventByEventId } from "../../actions/graphql.api";
+import { useAuth0 } from "@auth0/auth0-react";
 
 const processStatusAction = (status, setStatusCallBack) => {
 	if (status === "Accepted") {
@@ -20,18 +22,38 @@ const processStatusAction = (status, setStatusCallBack) => {
 	setStatusCallBack(status);
 };
 
-const RsvpEvent = () => {
+const showError = (error) => {
+	notification.error({
+		message: "Error",
+		description: "We couldn't add your participant due to error: " + error,
+	});
+};
+
+const RsvpEvent = (props) => {
+	const [eventData, setEventData] = useState({});
 	const [status, setStatus] = useState(null);
+	const { getAccessTokenSilently } = useAuth0();
+	const eventId = parseInt(props.match.params.id);
+
+	// Rendering event info
+	useEffect(() => {
+		getEventByEventId(
+			eventId,
+			getAccessTokenSilently(),
+			(d) => setEventData(d.getEvent),
+			showError
+		);
+	}, [getAccessTokenSilently, eventId]);
+
 	return (
 		<>
 			<Row gutter={[30, 30]} justify="center">
 				<ResponsiveColumn style={{ padding: 40 }} lg={9} md={9}>
 					<DetailCard
-						title="You are invited"
-						date="date"
-						startTime="9:00 am"
-						location="My House"
-						participants="12 people"
+						title={eventData.description}
+						date={eventData.date}
+						startTime={eventData.start_time}
+						location={eventData.location}
 						actions={[
 							<Button
 								testid="going-btn"

--- a/client/src/pages/RsvpEvent/RsvpEvent.test.js
+++ b/client/src/pages/RsvpEvent/RsvpEvent.test.js
@@ -2,14 +2,23 @@ import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import RsvpEvent from "./RsvpEvent";
+import { useAuth0 } from "@auth0/auth0-react";
+
+jest.mock("./../../actions/graphql.api");
+
+jest.mock("@auth0/auth0-react");
+useAuth0.mockReturnValue({
+	user: jest.fn(),
+	getAccessTokenSilently: jest.fn(),
+});
 
 describe("rsvp events ", () => {
 	test("renders rsvp event page", () => {
-		render(<RsvpEvent />);
+		render(<RsvpEvent match={{ params: { id: 1 } }} />);
 	});
 
 	test("verify answer is given and set", () => {
-		const { getByTestId } = render(<RsvpEvent />);
+		const { getByTestId } = render(<RsvpEvent match={{ params: { id: 1 } }} />);
 		expect(getByTestId("going-btn")).not.toHaveAttribute("disabled");
 		expect(getByTestId("not-going-btn")).not.toHaveAttribute("disabled");
 		fireEvent.click(getByTestId("going-btn"));

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "development": {
     "username": "root",
-    "password": "database",
+    "password": "server_password",
     "database": "db_secret_santa",
     "host": "127.0.0.1",
     "dialect": "mysql"

--- a/graphqlSchema/schema.js
+++ b/graphqlSchema/schema.js
@@ -186,6 +186,18 @@ var root = {
 	deleteParticipant: ({ id }) => {
 		return db.Participant.destroy({ where: { id: id } });
 	},
+	updateParticipantAccepted: ({ id }) => {
+		return db.Participant.update(
+			{ invite_status: "Accepted" },
+			{ where: { id: id }, returning: true, plain: true }
+		);
+	},
+	updateParticipantRejected: ({ id }) => {
+		return db.Participant.update(
+			{ invite_status: "Rejected" },
+			{ where: { id: id }, returning: true, plain: true }
+		);
+	},
 	getGifts: () => {
 		return db.Gift.findAll();
 	},

--- a/graphqlSchema/schema.js
+++ b/graphqlSchema/schema.js
@@ -92,7 +92,7 @@ var schema = buildSchema(`
 		assignSecretSanta(participant_id: Int, secret_santa_id: Int): [Int],
 		autoAssignSecretSanta(eventId: Int): [ParticipantSanta],
 		updateParticipantAccepted(id: Int): Participant,
-		updateParticipantRejected(id: Int): Particpant,
+		updateParticipantRejected(id: Int): Participant,
 	}
 
 `);

--- a/graphqlSchema/schema.js
+++ b/graphqlSchema/schema.js
@@ -91,6 +91,8 @@ var schema = buildSchema(`
 		deleteGift(id: Int): Int,
 		assignSecretSanta(participant_id: Int, secret_santa_id: Int): [Int],
 		autoAssignSecretSanta(eventId: Int): [ParticipantSanta],
+		updateParticipantAccepted(id: Int): Participant,
+		updateParticipantRejected(id: Int): Particpant,
 	}
 
 `);


### PR DESCRIPTION
#### Summary of Changes
With this branch, all functionality for the participant RSVP feature has been added. Here is a list of items that were completed / incorporated:

- [x] Updated event card on RSVP page to pull dynamic event details for each applicable event
- [x] When clicking the "going" button on the RSVP page, the participant is redirected to the participant event page.
- [x] When clicking the " not going" button on the RSVP page, the participant is redirected to the create event page.
- [x] Any participants that are "not going" are filtered out of participant table but still counted in the "rejected" column in the bar chart
- [x] All status (pending, accepted, and rejected) read on the front-end bar chart and back-end db

closes #122 
closes #124 

#### Sample Event Organizer Page on Heroku
![image](https://user-images.githubusercontent.com/58799056/94759562-da101780-0365-11eb-8097-17ed88efa6f0.png)

#### Sample RSVP Page on Heroku
![image](https://user-images.githubusercontent.com/58799056/94759500-b947c200-0365-11eb-8130-bbf908372656.png)

#### Sample Email to Confirm Functionality
![image](https://user-images.githubusercontent.com/58799056/94759620-01ff7b00-0366-11eb-8dd6-ea3e929a0c81.png)
